### PR TITLE
Add ed25519Verify and secp256k1Verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ ls build/docs/javadoc
 <dependency>
     <groupId>io.github.qyvlik</groupId>
     <artifactId>io.iost-java-sdk</artifactId>
-    <version>broker-v3.0.8</version>
+    <version>broker-v3.1.0</version>
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'io.iost'
-version '3.0.8'
+version '3.1.0'
 
 apply plugin: 'java'
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,5 +17,5 @@ dependencies {
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.60'
 
     // https://mvnrepository.com/artifact/org.web3j/crypto
-    compile group: 'org.web3j', name: 'crypto', version: '3.0.1'
+    compile group: 'org.web3j', name: 'crypto', version: '3.6.0'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.qyvlik</groupId>
     <artifactId>io.iost-java-sdk</artifactId>
-    <version>broker-v3.0.8</version>
+    <version>broker-v3.1.0</version>
     <name>io.iost-java-sdk</name>
     <description>iost.io java-sdk</description>
     <url>https://github.com/qyvlik/io.iost-java-sdk</url>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.web3j</groupId>
             <artifactId>crypto</artifactId>
-            <version>3.0.1</version>
+            <version>3.6.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/iost/crypto/Ed25519.java
+++ b/src/main/java/iost/crypto/Ed25519.java
@@ -57,4 +57,9 @@ public class Ed25519 extends KeyPair {
     public byte[] seckey() {
         return this.privateKey;
     }
+
+    @Override
+    public boolean verify(byte[] hash, byte[] signature) {
+        throw new RuntimeException("not implement yet");
+    }
 }

--- a/src/main/java/iost/crypto/Ed25519.java
+++ b/src/main/java/iost/crypto/Ed25519.java
@@ -2,8 +2,6 @@ package iost.crypto;
 
 import iost.model.transaction.Signature;
 
-import java.util.Arrays;
-
 /**
  * Ed25519 key pair
  */
@@ -22,9 +20,10 @@ public class Ed25519 extends KeyPair {
 
     /**
      * new key pair with given private key
+     *
      * @param seckey - private key
      */
-    public Ed25519(byte[] seckey){
+    public Ed25519(byte[] seckey) {
         int l = 32;
         if (seckey.length < 32) {
             l = seckey.length;
@@ -38,7 +37,7 @@ public class Ed25519 extends KeyPair {
 
     @Override
     public Signature sign(byte[] info) {
-        byte[]sig = TweetNaCl.crypto_sign(info, this.privateKey);
+        byte[] sig = TweetNaCl.crypto_sign(info, this.privateKey);
 
         Signature signature = new Signature();
         signature.signature = sig;
@@ -59,7 +58,7 @@ public class Ed25519 extends KeyPair {
     }
 
     @Override
-    public boolean verify(byte[] hash, byte[] signature) {
-        throw new RuntimeException("not implement yet");
+    public boolean verify(byte[] info, byte[] signature) {
+        return VerifyUtils.Ed25519Verify(info, signature, pubkey());
     }
 }

--- a/src/main/java/iost/crypto/KeyPair.java
+++ b/src/main/java/iost/crypto/KeyPair.java
@@ -45,5 +45,6 @@ public abstract class KeyPair {
     abstract public Signature sign(byte[] info);
     abstract public byte[] pubkey();
     abstract public byte[] seckey();
+    abstract public boolean verify(byte[] info, byte[] signature);
 }
 

--- a/src/main/java/iost/crypto/Secp256k1.java
+++ b/src/main/java/iost/crypto/Secp256k1.java
@@ -68,31 +68,17 @@ public class Secp256k1 extends KeyPair {
     }
 
     /**
+     * verify Secp256k1 signature
+     *
      * @param info      info
      * @param signature signature
      * @return verify result
      */
     @Override
     public boolean verify(byte[] info, byte[] signature) {
-        // ref: https://github.com/web3j/web3j/blob/v3.6.0/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java
-
-        byte[] r = Arrays.copyOfRange(signature, 0, 32);
-        byte[] s = Arrays.copyOfRange(signature, 32, 64);
-        ECDSASignature ecdsaSignature = new ECDSASignature(new BigInteger(r), new BigInteger(s));
-
-        // don't use the Secp256k1::pubkey to get the pubKeyInteger
-        // because the Secp256k1::pubkey only return part data.
-        BigInteger fullPubKeyInteger = Sign.publicKeyFromPrivate(new BigInteger(seckey()));
-
-        boolean match = false;
-        // Iterate for each possible key to recover
-        for (int i = 0; i < 4; i++) {
-            BigInteger recoverPublicKey = Sign.recoverFromSignature(i, ecdsaSignature, info);
-            if (recoverPublicKey != null && fullPubKeyInteger.compareTo(recoverPublicKey) == 0) {
-                match = true;
-                break;
-            }
-        }
-        return match;
+        assert seckey() != null;
+        // note: the Secp256k1::pubkey return part data, check full pubkey maybe necessary
+        byte[] pubKey = Sign.publicKeyFromPrivate(new BigInteger(seckey())).toByteArray();
+        return VerifyUtils.Secp256k1Verify(info, signature, pubKey);
     }
 }

--- a/src/main/java/iost/crypto/VerifyUtils.java
+++ b/src/main/java/iost/crypto/VerifyUtils.java
@@ -46,8 +46,16 @@ public class VerifyUtils {
                 throw new RuntimeException("Secp256k1Verify failure : pubKey is invalidate");
             }
             publicKey = Arrays.copyOfRange(pubKey, 1, 33);
-        } else if (pubKey.length == 32 || pubKey.length == 64) {
+        } else if (pubKey.length == 65) {
+            // todo what is pubKey[0]?
+            // if (pubKey[0] != (byte) 0x02) {
+            //    throw new RuntimeException("Secp256k1Verify failure : pubKey is invalidate");
+            // }
+            publicKey = Arrays.copyOfRange(pubKey, 1, 64);
+        } else if (pubKey.length == 32) {
             publicKey = Arrays.copyOfRange(pubKey, 0, 32);
+        } else if (pubKey.length == 64) {
+            publicKey = Arrays.copyOfRange(pubKey, 0, 64);
         } else {
             throw new RuntimeException("Secp256k1Verify failure : pubKey length is invalidate");
         }
@@ -56,7 +64,6 @@ public class VerifyUtils {
         // Iterate for each possible key to recover
         for (int i = 0; i < 4; i++) {
             BigInteger recoverPublicKey = Sign.recoverFromSignature(i, ecdsaSignature, info);
-
             if (recoverPublicKey != null) {
                 byte[] recoverPubKey = Arrays.copyOfRange(
                         recoverPublicKey.toByteArray(), 0, publicKey.length);

--- a/src/main/java/iost/crypto/VerifyUtils.java
+++ b/src/main/java/iost/crypto/VerifyUtils.java
@@ -1,0 +1,71 @@
+package iost.crypto;
+
+import org.web3j.crypto.ECDSASignature;
+import org.web3j.crypto.Sign;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+public class VerifyUtils {
+
+    /**
+     * verify ed25519 signature
+     * ref: https://github.com/iost-official/java-sdk/issues/4
+     *
+     * @param info      info
+     * @param signature signature
+     * @param pubKey    pubKey
+     * @return verify result
+     */
+    public static boolean Ed25519Verify(byte[] info, byte[] signature, byte[] pubKey) {
+        byte[] messageWithSignature = new byte[signature.length + info.length];
+        System.arraycopy(signature, 0, messageWithSignature, 0, signature.length);
+        System.arraycopy(info, 0, messageWithSignature, signature.length, info.length);
+        byte[] openMessage = TweetNaCl.crypto_sign_open(messageWithSignature, pubKey);
+        return Arrays.equals(info, openMessage);
+    }
+
+    /**
+     * verify Secp256k1 signature
+     * ref: https://github.com/web3j/web3j/blob/v3.6.0/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java
+     *
+     * @param info      info
+     * @param signature signature
+     * @param pubKey    pubKey
+     * @return verify result
+     */
+    public static boolean Secp256k1Verify(byte[] info, byte[] signature, byte[] pubKey) {
+        byte[] r = Arrays.copyOfRange(signature, 0, 32);
+        byte[] s = Arrays.copyOfRange(signature, 32, 64);
+        ECDSASignature ecdsaSignature = new ECDSASignature(new BigInteger(r), new BigInteger(s));
+
+        byte[] publicKey = null;
+        // remove head
+        if (pubKey.length == 33) {
+            if (pubKey[0] != (byte) 0x02) {
+                throw new RuntimeException("Secp256k1Verify failure : pubKey is invalidate");
+            }
+            publicKey = Arrays.copyOfRange(pubKey, 1, 33);
+        } else if (pubKey.length == 32 || pubKey.length == 64) {
+            publicKey = Arrays.copyOfRange(pubKey, 0, 32);
+        } else {
+            throw new RuntimeException("Secp256k1Verify failure : pubKey length is invalidate");
+        }
+
+        boolean match = false;
+        // Iterate for each possible key to recover
+        for (int i = 0; i < 4; i++) {
+            BigInteger recoverPublicKey = Sign.recoverFromSignature(i, ecdsaSignature, info);
+
+            if (recoverPublicKey != null) {
+                byte[] recoverPubKey = Arrays.copyOfRange(
+                        recoverPublicKey.toByteArray(), 0, publicKey.length);
+                if (Arrays.equals(recoverPubKey, publicKey)) {
+                    match = true;
+                    break;
+                }
+            }
+        }
+        return match;
+    }
+}

--- a/src/test/java/ECDSA_secp256k1_Test.java
+++ b/src/test/java/ECDSA_secp256k1_Test.java
@@ -1,0 +1,81 @@
+import iost.crypto.Base58;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+import org.web3j.crypto.ECKeyPair;
+import org.web3j.crypto.Hash;
+import org.web3j.crypto.Sign;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.SignatureException;
+
+// ECDSA with secp256k1 in Java: generate ECC keys, sign, verify
+// ref: https://gist.github.com/nakov/b01f9434df3350bc9b1cbf9b04ddb605
+// other ref: https://metamug.com/article/security/sign-verify-digital-signature-ecdsa-java.html
+public class ECDSA_secp256k1_Test {
+    public static String compressPubKey(BigInteger pubKey) {
+        String pubKeyYPrefix = pubKey.testBit(0) ? "03" : "02";
+        String pubKeyHex = pubKey.toString(16);
+        String pubKeyX = pubKeyHex.substring(0, 64);
+        return pubKeyYPrefix + pubKeyX;
+    }
+
+    @Test
+    public void test1() throws SignatureException {
+        //BigInteger privKey = Keys.createEcKeyPair().getPrivateKey();
+        BigInteger privKey = new BigInteger("97ddae0f3a25b92268175400149d65d6887b9cefaf28ea2c078e05cdc15a3c0a", 16);
+        BigInteger pubKey = Sign.publicKeyFromPrivate(privKey);
+        ECKeyPair keyPair = new ECKeyPair(privKey, pubKey);
+        System.out.println("Private key: " + privKey.toString(16));
+        System.out.println("Public key: " + pubKey.toString(16));
+        System.out.println("Public key (compressed): " + compressPubKey(pubKey));
+
+        String msg = "Message for signing";
+        byte[] msgHash = Hash.sha3(msg.getBytes());
+        Sign.SignatureData signature = Sign.signMessage(msgHash, keyPair, false);
+        System.out.println("Msg: " + msg);
+        System.out.println("Msg hash: " + Hex.toHexString(msgHash));
+        System.out.printf("Signature: [v = %d, r = %s, s = %s]\n",
+                signature.getV() - 27,
+                Hex.toHexString(signature.getR()),
+                Hex.toHexString(signature.getS()));
+
+        System.out.println();
+
+        BigInteger pubKeyRecovered = Sign.signedMessageToKey(msg.getBytes(), signature);
+        System.out.println("Recovered public key: " + pubKeyRecovered.toString(16));
+
+        boolean validSig = pubKey.equals(pubKeyRecovered);
+        System.out.println("Signature valid? " + validSig);
+    }
+
+
+    @Test
+    public void test2() throws SignatureException, IOException {
+        byte[] seckey = Base58.decode("EhNiaU4DzUmjCrvynV3gaUeuj2VjB1v2DCmbGD5U2nSE");
+        BigInteger privKey = new BigInteger(seckey);
+        BigInteger pubKey = Sign.publicKeyFromPrivate(privKey);
+        ECKeyPair keyPair = new ECKeyPair(privKey, pubKey);
+        System.out.println("Private key: " + privKey.toString(16));
+        System.out.println("Public key: " + pubKey.toString(16));
+        System.out.println("Public key (compressed): " + compressPubKey(pubKey));
+
+        String msg = "Message for signing";
+        byte[] msgHash = Hash.sha3(msg.getBytes());
+        Sign.SignatureData signature = Sign.signMessage(msgHash, keyPair, false);
+        System.out.println("Msg: " + msg);
+        System.out.println("Msg hash: " + Hex.toHexString(msgHash));
+        System.out.printf("Signature: [v = %d, r = %s, s = %s]\n",
+                signature.getV() - 27,
+                Hex.toHexString(signature.getR()),
+                Hex.toHexString(signature.getS()));
+
+        System.out.println();
+
+        BigInteger pubKeyRecovered = Sign.signedMessageToKey(msg.getBytes(), signature);
+        System.out.println("Recovered public key: " + pubKeyRecovered.toString(16));
+
+        boolean validSig = pubKey.equals(pubKeyRecovered);
+        System.out.println("Signature valid? " + validSig);
+    }
+}

--- a/src/test/java/TestCrypto.java
+++ b/src/test/java/TestCrypto.java
@@ -69,6 +69,22 @@ public class TestCrypto {
     }
 
     @Test
+    public void testEd25519Verify() throws InvalidKeySpecException, IOException {
+        byte[] seckey = Base58.decode("1rANSfcRzr4HkhbUFZ7L1Zp69JZZHiDDq5v7dNSbbEqeU4jxy3fszV4HGiaLQEyqVpS1dKT9g7zCVRxBVzuiUzB");
+
+        Ed25519 e = new Ed25519(seckey);
+        assertEquals("5731adeb5d1a807ec9c43825389e5edff70412e4643a94629a652af1bfcf2f08", Hex.toHexString(e.pubkey()));
+
+        byte[] info = (new SHA3.Digest256()).digest("hello".getBytes());
+        assertEquals("3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392", Hex.toHexString(info));
+        Signature signature = e.sign(info);
+        assertEquals("eb436f1af8502d454f8bcea472bac4015f7827d7f90427ce22787f14bf98b83d2c2b4d1b303ad4201b1526a1a269f069dcbf2887a636799b8e733acd2fd75308",
+                Hex.toHexString(signature.signature));
+        assertTrue(e.verify(info, signature.signature));
+
+    }
+
+    @Test
     public void testSHA3_256() {
         byte[] info = (new SHA3.Digest256()).digest("hello".getBytes());
         assertEquals("3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392", Hex.toHexString(info));

--- a/src/test/java/TestCrypto.java
+++ b/src/test/java/TestCrypto.java
@@ -1,6 +1,9 @@
 import com.google.gson.GsonBuilder;
 import iost.Keychain;
-import iost.crypto.*;
+import iost.crypto.Base58;
+import iost.crypto.Ed25519;
+import iost.crypto.KeyPair;
+import iost.crypto.Secp256k1;
 import iost.model.transaction.Signature;
 import iost.model.transaction.SignatureAdapter;
 import iost.model.transaction.Transaction;
@@ -8,11 +11,11 @@ import org.bouncycastle.jcajce.provider.digest.SHA3;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 
-
 import java.io.IOException;
 import java.security.spec.InvalidKeySpecException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TestCrypto {
     @Test
@@ -33,6 +36,21 @@ public class TestCrypto {
     }
 
     @Test
+    public void testSecp256k1Verify() throws IOException {
+        byte[] seckey = Base58.decode("EhNiaU4DzUmjCrvynV3gaUeuj2VjB1v2DCmbGD5U2nSE");
+        Secp256k1 s = new Secp256k1(seckey);
+
+        assertEquals("02069b1abdaaf8326e7e6fc15607fd9e6c6f595e119a2484a4192b5d6b3878dd25", Hex.toHexString(s.pubkey()));
+        byte[] info = (new SHA3.Digest256()).digest("hello".getBytes());
+        assertEquals("3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392", Hex.toHexString(info));
+        Signature signature = s.sign(info);
+        assertEquals("37f7731bdb9988aa330be8bbd6a791f11d9fe90601edf7f569f6b8ddcfdd7755333b299ca3a8437e71eb14c72a02a2c5cdf3562e891f5a3c1d54d92148236e10",
+                Hex.toHexString(signature.signature));
+
+        assertTrue(s.verify(info, signature.signature));
+    }
+
+    @Test
     public void testEd25519() throws InvalidKeySpecException, IOException {
         byte[] seckey = Base58.decode("1rANSfcRzr4HkhbUFZ7L1Zp69JZZHiDDq5v7dNSbbEqeU4jxy3fszV4HGiaLQEyqVpS1dKT9g7zCVRxBVzuiUzB");
 
@@ -46,8 +64,14 @@ public class TestCrypto {
                 Hex.toHexString(signature.signature));
 
         KeyPair s2 = new Ed25519();
-        System.out.println("\"" + (new Ed25519()).B58SecKey()+ "\",");
+        System.out.println("\"" + (new Ed25519()).B58SecKey() + "\",");
 
+    }
+
+    @Test
+    public void testSHA3_256() {
+        byte[] info = (new SHA3.Digest256()).digest("hello".getBytes());
+        assertEquals("3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392", Hex.toHexString(info));
     }
 
     @Test

--- a/src/test/java/crypto_sign_open.java
+++ b/src/test/java/crypto_sign_open.java
@@ -1,0 +1,29 @@
+import iost.crypto.Ed25519;
+import iost.crypto.KeyPair;
+import iost.crypto.TweetNaCl;
+import org.junit.Test;
+
+// ref: https://github.com/iost-official/java-sdk/issues/4
+public class crypto_sign_open {
+
+    @Test
+    public void test() {
+        String message = "hello world";
+        KeyPair k = new Ed25519();
+
+        System.out.println(k.B58SecKey());
+        System.out.println(k.B58PubKey());
+
+        byte[] info = message.getBytes();
+
+        byte[] signature = TweetNaCl.crypto_sign(info, k.seckey());
+
+        byte[] messageWithSignature = new byte[signature.length + info.length];
+        System.arraycopy(signature, 0, messageWithSignature, 0, signature.length);
+        System.arraycopy(info, 0, messageWithSignature, signature.length, info.length);
+        byte[] openMessage = TweetNaCl.crypto_sign_open(messageWithSignature, k.pubkey());
+
+        System.out.println(new String(signature));
+        System.out.println(new String(openMessage));
+    }
+}

--- a/src/test/java/iost/crypto/VerifyUtilsTest.java
+++ b/src/test/java/iost/crypto/VerifyUtilsTest.java
@@ -1,0 +1,49 @@
+package iost.crypto;
+
+import iost.model.transaction.Signature;
+import org.bouncycastle.jcajce.provider.digest.SHA3;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class VerifyUtilsTest {
+    @Test
+    public void ed25519Verify() throws Exception {
+
+        byte[] seckey = Base58.decode("1rANSfcRzr4HkhbUFZ7L1Zp69JZZHiDDq5v7dNSbbEqeU4jxy3fszV4HGiaLQEyqVpS1dKT9g7zCVRxBVzuiUzB");
+
+        Ed25519 e = new Ed25519(seckey);
+        byte[] pubKey = e.pubkey();
+        assertEquals("5731adeb5d1a807ec9c43825389e5edff70412e4643a94629a652af1bfcf2f08", Hex.toHexString(pubKey));
+
+        byte[] info = (new SHA3.Digest256()).digest("hello".getBytes());
+        assertEquals("3338be694f50c5f338814986cdf0686453a888b84f424d792af4b9202398f392", Hex.toHexString(info));
+        Signature signature = e.sign(info);
+        assertEquals("eb436f1af8502d454f8bcea472bac4015f7827d7f90427ce22787f14bf98b83d2c2b4d1b303ad4201b1526a1a269f069dcbf2887a636799b8e733acd2fd75308",
+                Hex.toHexString(signature.signature));
+        assertTrue(e.verify(info, signature.signature));
+
+        // verify without seckey
+        assertTrue(VerifyUtils.Ed25519Verify(info, signature.signature, pubKey));
+    }
+
+    @Test
+    public void secp256k1Verify() throws Exception {
+        byte[] seckey = Base58.decode("EhNiaU4DzUmjCrvynV3gaUeuj2VjB1v2DCmbGD5U2nSE");
+        Secp256k1 s = new Secp256k1(seckey);
+        byte[] pubKey = s.pubkey();
+        assertEquals("02069b1abdaaf8326e7e6fc15607fd9e6c6f595e119a2484a4192b5d6b3878dd25", Hex.toHexString(pubKey));
+        byte[] info = (new SHA3.Digest256()).digest("hello".getBytes());
+        Signature signature = s.sign(info);
+        assertEquals("37f7731bdb9988aa330be8bbd6a791f11d9fe90601edf7f569f6b8ddcfdd7755333b299ca3a8437e71eb14c72a02a2c5cdf3562e891f5a3c1d54d92148236e10",
+                Hex.toHexString(signature.signature));
+
+        assertTrue(s.verify(info, signature.signature));
+
+        // verify without seckey
+        assertTrue(VerifyUtils.Secp256k1Verify(info, signature.signature, pubKey));
+    }
+
+}


### PR DESCRIPTION
# Add ed25519Verify and secp256k1Verify

## use case

### with private key

```
byte[] seckey = ...
byte[] info = ...
Ed25519 e = new Ed25519(seckey);
Signature signature = e.sign(info);
assertTrue(e.verify(info, signature.signature));
```

### without private key

```
byte[] pubKey = ...
byte[] info = ...
byte[] signature = ...
assertTrue(VerifyUtils.Ed25519Verify(info,signature, pubKey));
```

## ref

> ed25519 公钥长度 32 私钥长度 64 （实际上后32byte就是公钥，不过从私钥到公钥计算量较大，传统上都拼在一起用）
> seck256k1 公钥长度 32 私钥长度 32.
> 个别格式可能前缀个特定byte，长度就是 33 或者 65.

## code ref

> - verify ed25519 signature : https://github.com/iost-official/java-sdk/issues/4
> - verify Secp256k1 signature: https://github.com/web3j/web3j/blob/v3.6.0/crypto/src/test/java/org/web3j/crypto/ECRecoverTest.java