### PR TITLE
support lowest digits after the decimal point

### DIFF
--- a/src/main/java/iost/Client.java
+++ b/src/main/java/iost/Client.java
@@ -1,7 +1,6 @@
 package iost;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.google.gson.*;
 import iost.model.account.*;
 import iost.model.block.*;
 import iost.model.info.*;
@@ -10,6 +9,7 @@ import okhttp3.*;
 
 import java.io.IOException;
 import java.util.Date;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -36,6 +36,7 @@ public class Client {
         this.client = new OkHttpClient();
         GsonBuilder gb = new GsonBuilder();
         gb.registerTypeAdapter(Signature.class, new SignatureAdapter());
+        gb.registerTypeAdapter(BigDecimal.class, (JsonSerializer<BigDecimal>) (src, typeOfSrc, context) -> new JsonPrimitive(src.toPlainString()));
         this.gson = gb.create();
     }
 

--- a/src/main/java/iost/IOST.java
+++ b/src/main/java/iost/IOST.java
@@ -63,8 +63,8 @@ public class IOST {
      * @return -
      */
     public Transaction transfer(String token, String from, String to, BigDecimal amount, String memo) {
-        Transaction tx = this.callABI("token.iost", "transfer", token, from, to, amount.toString(), memo);
-        tx.addApprove(token, amount.toString());
+        Transaction tx = this.callABI("token.iost", "transfer", token, from, to, amount.stripTrailingZeros().toPlainString(), memo);
+        tx.addApprove(token, amount.stripTrailingZeros().toPlainString());
 
         return tx;
     }


### PR DESCRIPTION
I found that transaction amount is not supported lowest digits(8 digits) after the decimal point.

This caused by the method `Java.math.BigDecimal.toString()`. If the digits is 8, it represents an exponent field.

You should use `Java.math.BigDecimal.toPlainString()`.